### PR TITLE
Update CyanPlayerObjectAssigner.cs

### DIFF
--- a/com.cyan.playerobjectpool/UdonSharp/CyanPlayerObjectAssigner.cs
+++ b/com.cyan.playerobjectpool/UdonSharp/CyanPlayerObjectAssigner.cs
@@ -174,6 +174,11 @@ namespace Cyan.PlayerObjectPool
         [PublicAPI]
         public GameObject _GetPlayerPooledObjectById(int playerId)
         {
+            if (!_enabledAndInitialized)
+            {
+                return null;
+            }
+            
             int index = _objectPool._GetPlayerPoolIndexById(playerId);
 
             if (index == -1)


### PR DESCRIPTION
Fix a error that would occur if another script tried to request the players pooled object before initialization